### PR TITLE
CSS and HTML refactoring to remove styling information from html

### DIFF
--- a/Blazor/Pages/Game.razor
+++ b/Blazor/Pages/Game.razor
@@ -15,9 +15,8 @@
                     if (Board.IsOccupied(rank, file))
                     {
                         <button class="tile" 
-                            draggable="true" 
-                            data-tile-type="@TileType(rank, file)"
-                            data-tile-is-selected="@IsSelected(rank, file)" 
+                            draggable="true"
+                            selected="@IsSelected(rank, file)"
                             @ondragenter:preventDefault 
                             @ondragleave:preventDefault
                             @ondragover:preventDefault 
@@ -31,7 +30,7 @@
                     }
                     else
                     {
-                        <button class="tile" data-tile-type="@TileType(rank, file)">@nbsp</button>
+                        <button class="tile">@nbsp</button>
                     }
                 }
                 <br />
@@ -176,12 +175,6 @@ else
         await base.OnInitializedAsync();
     }
 
-    private string TileType(int rank, char file)
-    {
-        if ((rank + file) % 2 == 0) { return "white"; }
-        return "black";
-    }
-
     private bool IsSelected(int rank, char file) => _gameState.SelectedPosition == new Position(rank, file);
 
     private void HandleDragStart(int rank, char file)
@@ -221,12 +214,12 @@ else
     {
         return piece switch
         {
-            ChessPiece.Pawn => "♟︎",
-            ChessPiece.Rook => "♜",
+            ChessPiece.Pawn   => "♟︎",
+            ChessPiece.Rook   => "♜",
             ChessPiece.Bishop => "♝",
             ChessPiece.Knight => "♞",
-            ChessPiece.Queen => "♛",
-            ChessPiece.King => "♚",
+            ChessPiece.Queen  => "♛",
+            ChessPiece.King   => "♚",
             _ => throw new Exception("YOU LOSE! YOU GET NOTHING!"),
         };
     }

--- a/Blazor/Pages/Game.razor.css
+++ b/Blazor/Pages/Game.razor.css
@@ -54,15 +54,15 @@ a {
     aspect-ratio: 1;
     width: 1.5em;
 }
-.tile[data-tile-type="white"] {
+#board .tile:nth-child(odd) {
     background-color: #d3b083;
 }
 
-.tile[data-tile-type="black"] {
+#board .tile:nth-child(even) {
     background-color: #4f4f4f;
 }
 
-.tile[data-tile-is-selected] {
+#board .tile[selected] {
     background-color: #ffa100;
 }
 


### PR DESCRIPTION
This isn't necessarily for merging, but it shows the approach that I would take to solve this given the HTML layout of div with buttons and breaks that you chose.

This css only works for even sized grids, but it it is fairly easy to extend to other sizes as well.

Note the syntax for setting attributes. The attribute only appears in the html when the condition is true.

I use this when the attribute is only there to show some interim status (I use data attributes when the information should always be there. Like a numerical value for a displayed string)